### PR TITLE
Update 2020-07-31-pertsch20a.md

### DIFF
--- a/_posts/2020-07-31-pertsch20a.md
+++ b/_posts/2020-07-31-pertsch20a.md
@@ -22,7 +22,7 @@ lastpage: 979
 page: 969-979
 order: 969
 cycles: false
-bibtex_author: Pertsch, Karl and Rybkin, Oleh and Yang, Jingyun and Derpanis, Konstantinos
+bibtex_author: Pertsch, Karl and Rybkin, Oleh and Yang, Jingyun and Zhou, Shenghao and Derpanis, Konstantinos
   and Daniilidis, Kostas and Lim, Joseph and Jaegle, Andrew
 author:
 - given: Karl
@@ -31,6 +31,8 @@ author:
   family: Rybkin
 - given: Jingyun
   family: Yang
+- given: Shenghao  
+  family: Zhou
 - given: Konstantinos
   family: Derpanis
 - given: Kostas


### PR DESCRIPTION
I would like to change the "Keyframing the Future: Keyframe Discovery for Visual Prediction and Planning" entry to add a mistakenly omitted author. The author is already in the pdf and the organizers (Claire Tomlin) are aware of this change.